### PR TITLE
Enhance Invoke-ChatCompletion to support environment variable for Tex…

### DIFF
--- a/Public/Invoke-ChatCompletion.ps1
+++ b/Public/Invoke-ChatCompletion.ps1
@@ -94,7 +94,7 @@ function Invoke-ChatCompletion {
     }
     
     # Return the result based on the TextOnly switch
-    if ($TextOnly) {
+    if ($TextOnly -or [System.Convert]::ToBoolean($env:PSAISUITE_TEXT_ONLY)) {
         # Format the text output to include the elapsed time if requested
         if ($IncludeElapsedTime) {
             return "$responseText`n`nElapsed Time: $($elapsedTime.ToString('hh\:mm\:ss\.fff'))"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ foreach($model in $models) {
 }
 ```
 
+### Generate Chat Completions - Return Text Only
+```powershell
+# Import the module
+Import-Module PSAISuite
+
+$message = New-ChatMessage -Prompt "What is the capital of France?"
+Invoke-ChatCompletion -Message $message -TextOnly
+# or by setting the environment variable
+
+$env:PSAISUITE_TEXT_ONLY=$true
+$message = New-ChatMessage -Prompt "What is the capital of France?"
+Invoke-ChatCompletion -Message $message 
+
+```
+
 Note that the model name in the Invoke-ChatCompletion call uses the format - `<provider>:<model-name>`.
 
 ## Adding support for a provider

--- a/__tests__/Invoke-ChatCompletion.Tests.ps1
+++ b/__tests__/Invoke-ChatCompletion.Tests.ps1
@@ -37,6 +37,14 @@ Describe "Invoke-ChatCompletion" {
             # Should -Invoke -ModuleName PSAISuite Invoke-OpenAIProvider -Times 1 -Exactly
         }
 
+        It "Returns text only when PSAISUITE_TEXT_ONLY environment variable is used" {
+            $env:PSAISUITE_TEXT_ONLY = "true"
+            $message = New-ChatMessage -Prompt "Test prompt"
+            $result = Invoke-ChatCompletion -Messages $message -TextOnly
+            $result | Should -BeOfType [string]
+            # Should -Invoke -ModuleName PSAISuite Invoke-OpenAIProvider -Times 1 -Exactly
+        }
+
         It "Returns object by default" {
             $message = New-ChatMessage -Prompt "Test prompt"
             $result = Invoke-ChatCompletion -Messages $message

--- a/__tests__/Invoke-ChatCompletion.Tests.ps1
+++ b/__tests__/Invoke-ChatCompletion.Tests.ps1
@@ -42,6 +42,7 @@ Describe "Invoke-ChatCompletion" {
             $message = New-ChatMessage -Prompt "Test prompt"
             $result = Invoke-ChatCompletion -Messages $message -TextOnly
             $result | Should -BeOfType [string]
+            $env:PSAISUITE_TEXT_ONLY = $null
             # Should -Invoke -ModuleName PSAISuite Invoke-OpenAIProvider -Times 1 -Exactly
         }
 


### PR DESCRIPTION
Per our conversation on twitter.
This PR implements the usage of `$env:PSAISUITE_TEXT_ONLY ` in order to globally set the TextOnly flag.


-DM