### PR TITLE
Add support to specify default model via environment variable

### DIFF
--- a/Public/Invoke-ChatCompletion.ps1
+++ b/Public/Invoke-ChatCompletion.ps1
@@ -53,6 +53,11 @@ function Invoke-ChatCompletion {
         [switch]$TextOnly,
         [switch]$IncludeElapsedTime
     )
+
+    if ($env:PSAISUITE_DEFAULT_MODEL) {
+        Write-Verbose "Using default model from environment variable `$env:PSAISUITE_DEFAULT_MODEL: $env:PSAISUITE_DEFAULT_MODEL"
+        $Model = $env:PSAISUITE_DEFAULT_MODEL
+    }
     
     # Convert string input to a proper message format if needed
     if ($Messages -is [string]) {

--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ $message = New-ChatMessage -Prompt "What is the capital of France?"
 Invoke-ChatCompletion -Message $message 
 
 ```
+### Generate Chat Completions - Using Custom Default Model
+```powershell
+# Import the module
+Import-Module PSAISuite
+
+$model = "openai:gpt-4o"
+$message = New-ChatMessage  -Prompt "What is the capital of France?"
+Invoke-ChatCompletion -Model $model -Message $message 
+
+# or by setting the environment variable
+$env:PSAISUITE_DEFAULT_MODEL = "openai:gpt-4o"
+$message = New-ChatMessage -Prompt "What is the capital of France?"
+Invoke-ChatCompletion -Message $message 
+
+```
 
 Note that the model name in the Invoke-ChatCompletion call uses the format - `<provider>:<model-name>`.
 

--- a/__tests__/Invoke-ChatCompletion.Tests.ps1
+++ b/__tests__/Invoke-ChatCompletion.Tests.ps1
@@ -75,7 +75,19 @@ Describe "Invoke-ChatCompletion" {
             #     $model -eq "claude-3-sonnet-20240229" -and $prompt -eq "Test prompt"
             # }
         }
-   
+
+        It "Uses specified model when provided via PSAISUITE_DEFAULT_MODEL environment variable" {
+            $env:PSAISUITE_DEFAULT_MODEL = "openai:gpt-4o"
+            $message = New-ChatMessage -Prompt "Test prompt"
+            $result = Invoke-ChatCompletion -Messages $message
+            $env:PSAISUITE_DEFAULT_MODEL = $null
+            $result | Should -BeOfType [PSCustomObject]
+            $result.Messages | Should -Be ($message | ConvertTo-Json -Compress)
+            $result.Response | Should -Not -BeNullOrEmpty
+            $result.Model | Should -Be "openai:gpt-4o"
+            # Should -Invoke -ModuleName PSAISuite Invoke-OpenAIProvider -Times 1 -Exactly
+        }
+
         It "Uses specified SystemRole when provided" {
             $message = New-ChatMessage -Prompt "Test prompt" -SystemRole "system" -SystemContent "you are a helpful powershell assistant, reply only with commands"
             $result = Invoke-ChatCompletion -Messages $message 


### PR DESCRIPTION
This PR adds a way to specify the default ai model via an environment variable.

```powershell
# or by setting the environment variable
$env:PSAISUITE_DEFAULT_MODEL = "openai:gpt-4o"
$message = New-ChatMessage -Prompt "What is the capital of France?"
Invoke-ChatCompletion -Message $message 
```