### PR TITLE
Rename $env:GITHUB_TOKEN to $env:GithubKey

### DIFF
--- a/Providers/GitHub.ps1
+++ b/Providers/GitHub.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     The Invoke-GitHubProvider function sends requests to the GitHub Models API and returns the generated content.
-    It requires a GitHub token to be set in the environment variable 'GITHUB_TOKEN'.
+    It requires a GitHub token to be set in the environment variable 'GithubKey'.
 
 .PARAMETER ModelName
     The name of the GitHub model to use (e.g., 'gpt-4o-mini'). Note: Model availability might change.
@@ -17,7 +17,7 @@
     $response = Invoke-GitHubProvider -ModelName 'gpt-4o-mini' -Messages $Message
 
 .NOTES
-    Requires the GITHUB_TOKEN environment variable to be set with a valid GitHub token with appropriate permissions.
+    Requires the GithubKey environment variable to be set with a valid GitHub token with appropriate permissions.
     The API endpoint used is 'https://models.inference.ai.azure.com/chat/completions'. This might be subject to change.
 #>
 function Invoke-GitHubProvider {
@@ -29,14 +29,14 @@ function Invoke-GitHubProvider {
         [hashtable[]]$Messages
     )
 
-    if (-not $env:GITHUB_TOKEN) {
-        Write-Error "Please set the GITHUB_TOKEN environment variable with a valid GitHub token."
+    if (-not $env:GithubKey) {
+        Write-Error "Please set the GithubKey environment variable with a valid GitHub token."
         return
     }
 
     $headers = @{
         "Content-Type"  = "application/json"
-        "Authorization" = "Bearer $($env:GITHUB_TOKEN)"
+        "Authorization" = "Bearer $($env:GithubKey)"
     }
 
     $body = @{

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set the API keys.
 $env:OpenAIKey="your-openai-api-key"
 $env:AnthropicKey="your-anthropic-api-key"
 $env:NebiusKey="your-nebius-api-key"
-$env:GITHUB_TOKEN="your-github-token" # Add GitHub token
+$env:GithubKey="your-github-token" # Add GitHub token
 # ... and so on for other providers
 ```
 

--- a/guides/github.md
+++ b/guides/github.md
@@ -6,10 +6,10 @@ This guide provides instructions on how to use the GitHub provider with `PSAISui
 
 To use the GitHub provider, you need a GitHub token with the necessary permissions to access the models API.
 
-Set the `GITHUB_TOKEN` environment variable:
+Set the `GithubKey` environment variable:
 
 ```powershell
-$env:GITHUB_TOKEN = "your-github-token"
+$env:GithubKey = "your-github-token"
 ```
 
 # Create a Chat Completion


### PR DESCRIPTION
Rename environment variable `$env:GITHUB_TOKEN` to `$env:GithubKey` across multiple files.

* **Guides and Documentation**
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `guides/github.md` setup and example code sections.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `README.md` setup and example code sections.

* **Provider Script**
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Providers/GitHub.ps1` function `Invoke-GitHubProvider`.

* **Example Scripts**
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/tryCodeGeneration.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/tryGroq.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/tryGroq-Parallel.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/try-Azure-DeployedModels.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/TestInvoke-ChatCompletion.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/TestInvoke-ChatCompletion-Basic.ps1`.
  - Replace `$env:GITHUB_TOKEN` with `$env:GithubKey` in `Examples/Test-Elapsed-Invoke-ChatCompletion.ps1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/the-mentor/psaisuite?shareId=XXXX-XXXX-XXXX-XXXX).