### PR TITLE
Create provider for fireworks.ai #13

### DIFF
--- a/PSAISuite.psd1
+++ b/PSAISuite.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'PSAISuite.psm1'
     
     # Version number of this module.
-    ModuleVersion     = '0.6.0'
+    ModuleVersion     = '0.7.0'
     
     # ID used to uniquely identify this module
     GUID              = 'f5a37b81-6a5a-4b5c-a6e1-2b8a5f9c2fd8'

--- a/Providers/FireworksAI.ps1
+++ b/Providers/FireworksAI.ps1
@@ -1,0 +1,158 @@
+<#
+.SYNOPSIS
+    Invokes the FireworksAI API to generate responses using specified models.
+
+.DESCRIPTION
+    The Invoke-FireworksAIProvider function sends requests to the FireworksAI API and returns the generated content.
+    It requires an API key to be set in the environment variable 'FireworksAIKey'.
+
+.PARAMETER ModelName
+    The name of the FireworksAI model to use (e.g., 'accounts/fireworks/models/deepseek-v3p1').
+
+.PARAMETER Messages
+    An array of hashtables containing the messages to send to the model.
+
+.PARAMETER Tools
+    An array of tool definitions for function calling. Can be strings (command names) or hashtables.
+
+.EXAMPLE
+    $Message = New-ChatMessage -Prompt 'Who and what are you'
+    $response = Invoke-FireworksAIProvider -ModelName 'deepseek-v3p1' -Messages $Message
+
+.EXAMPLE
+    $Message = New-ChatMessage -Prompt 'Who and what are you'
+    $response = Invoke-FireworksAIProvider -ModelName 'glm-5' -Messages $Message
+
+.EXAMPLE
+    $response = Invoke-FireworksAIProvider -ModelName 'glm-5' -Messages $messages -Tools "Get-ChildItem"
+
+.NOTES
+    Requires the FireworksAIKey environment variable to be set with a valid API key.
+    API Reference: https://docs.fireworks.ai/api-reference/post-chatcompletions
+#>
+function Invoke-FireworksAIProvider {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ModelName,
+        [Parameter(Mandatory)]
+        [hashtable[]]$Messages,
+        [object[]]$Tools
+    )
+
+    # Process tools: if strings, register them; then convert to provider schema
+    if ($Tools) {
+        $toolDefinitions = New-Object System.Collections.Generic.List[object]
+        foreach ($tool in $Tools) {
+            if ($tool -is [string]) {
+                $toolDefinitions.Add((Register-Tool $tool))
+            }
+            else {
+                $toolDefinitions.Add($tool)
+            }
+        }
+        $Tools = ConvertTo-ProviderToolSchema -Tools $toolDefinitions -Provider openai
+    }
+
+    if (-not $env:FireworksAIKey) {
+        Write-Error "Please set the FireworksAIKey environment variable with a valid FireworksAI API key."
+        return
+    }
+
+    $account_id = 'fireworks' # using the default 'fireworks' account as not yet supporting user accounts.
+    $internalModelName = "accounts/$account_id/models/$ModelName"
+
+    $headers = @{
+        Authorization  = "Bearer $env:FireworksAIKey"
+        'Content-Type' = 'application/json'
+    }
+
+    $body = @{
+        model    = $internalModelName
+        messages = [hashtable[]]$Messages
+    }
+
+    if ($Tools) {
+        $body['tools'] = $Tools
+    }
+
+    $Uri = "https://api.fireworks.ai/inference/v1/chat/completions"
+
+    $maxIterations = 5
+    $iteration = 0
+
+    while ($iteration -lt $maxIterations) {
+        $params = @{
+            Uri     = $Uri
+            Method  = 'POST'
+            Headers = $headers
+            Body    = $body | ConvertTo-Json -Depth 10
+        }
+
+        try {
+            $response = Invoke-RestMethod @params
+
+            if ($response.error) {
+                Write-Error $response.error.message
+                return "Error: $($response.error.message)"
+            }
+
+            if (!$response.choices -or $response.choices.Count -eq 0) {
+                return "No choices in response from API."
+            }
+
+            $assistantMessage = $response.choices[0].message
+
+            if ($assistantMessage.tool_calls) {
+                $body.messages += $assistantMessage
+
+                foreach ($call in $assistantMessage.tool_calls) {
+                    $functionName = $call.function.name
+                    $functionArgs = @{}
+                    if ($call.function.arguments) {
+                        $functionArgs = $call.function.arguments | ConvertFrom-Json -AsHashtable
+                    }
+
+                    try {
+                        if (Get-Command $functionName -ErrorAction SilentlyContinue) {
+                            $result = & $functionName @functionArgs
+                        }
+                        else {
+                            $result = "Error: Function $functionName not found"
+                        }
+                    }
+                    catch {
+                        $result = "Error: $($_.Exception.Message)"
+                    }
+
+                    $body.messages += @{
+                        role         = 'tool'
+                        tool_call_id = $call.id
+                        content      = $result | Out-String
+                    }
+                }
+            }
+            else {
+                $content = $assistantMessage.content
+                if ($content -is [array]) {
+                    $content = ($content | ForEach-Object { $_.text }) -join ''
+                }
+
+                if (!$content) {
+                    return "No text content in response."
+                }
+
+                return $content
+            }
+        }
+        catch {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            $errorMessage = $_.ErrorDetails.Message
+            Write-Error "FireworksAI API Error (HTTP $statusCode): $errorMessage"
+            return "Error calling FireworksAI API: $($_.Exception.Message)"
+        }
+
+        $iteration++
+    }
+
+    return "Maximum iterations reached without completing the response."
+}

--- a/Providers/FireworksAI.ps1
+++ b/Providers/FireworksAI.ps1
@@ -58,11 +58,12 @@ function Invoke-FireworksAIProvider {
         return
     }
 
-    # use the end-users account_id if the environment variable is set, else use the default 'fireworks' account_id
+    # Determine which account_id to use for the API URI:
+    # - If $env:FireworksID is set with the allowed pattern, use it (supports user with deployed models)
+    # - Otherwise, default the account_id to 'fireworks' (supports user without deployed models)
     if ($env:FireworksID -match '^[a-zA-Z0-9_-]+$') {
         $account_id = $env:FireworksID
-    }
-    else {
+    } else {
         $account_id = 'fireworks'
     }
 

--- a/Providers/FireworksAI.ps1
+++ b/Providers/FireworksAI.ps1
@@ -7,7 +7,7 @@
     It requires an API key to be set in the environment variable 'FireworksAIKey'.
 
 .PARAMETER ModelName
-    The name of the FireworksAI model to use (e.g., 'accounts/fireworks/models/deepseek-v3p1').
+    The name of the FireworksAI model to use (e.g., 'deepseek-v3p1').
 
 .PARAMETER Messages
     An array of hashtables containing the messages to send to the model.

--- a/Providers/FireworksAI.ps1
+++ b/Providers/FireworksAI.ps1
@@ -12,10 +12,6 @@
 .PARAMETER Messages
     An array of hashtables containing the messages to send to the model.
 
-.PARAMETER AccountID
-    (Optional) The account ID to use for the API request. Defaults to 'fireworks'.
-    This parameter is used when the user has deployed models in their own account.
-
 .PARAMETER Tools
     An array of tool definitions for function calling. Can be strings (command names) or hashtables.
 
@@ -40,8 +36,6 @@ function Invoke-FireworksAIProvider {
         [string]$ModelName,
         [Parameter(Mandatory)]
         [hashtable[]]$Messages,
-        [ValidatePattern('^[a-zA-Z0-9_-]+$')] # validate for safety - prevent injection attacks
-        [string]$AccountID = 'fireworks', # default account ID when users do not need to specify their own account
         [object[]]$Tools
     )
 

--- a/Providers/FireworksAI.ps1
+++ b/Providers/FireworksAI.ps1
@@ -12,6 +12,10 @@
 .PARAMETER Messages
     An array of hashtables containing the messages to send to the model.
 
+.PARAMETER AccountID
+    (Optional) The account ID to use for the API request. Defaults to 'fireworks'.
+    This parameter is used when the user has deployed models in their own account.
+
 .PARAMETER Tools
     An array of tool definitions for function calling. Can be strings (command names) or hashtables.
 
@@ -36,6 +40,8 @@ function Invoke-FireworksAIProvider {
         [string]$ModelName,
         [Parameter(Mandatory)]
         [hashtable[]]$Messages,
+        [ValidatePattern('^[a-zA-Z0-9_-]+$')] # validate for safety - prevent injection attacks
+        [string]$AccountID = 'fireworks', # default account ID when users do not need to specify their own account
         [object[]]$Tools
     )
 
@@ -58,7 +64,14 @@ function Invoke-FireworksAIProvider {
         return
     }
 
-    $account_id = 'fireworks' # using the default 'fireworks' account as not yet supporting user accounts.
+    # use the end-users account_id if the environment variable is set, else use the default 'fireworks' account_id
+    if ($env:FireworksID -match '^[a-zA-Z0-9_-]+$') {
+        $account_id = $env:FireworksID
+    }
+    else {
+        $account_id = 'fireworks'
+    }
+
     $internalModelName = "accounts/$account_id/models/$ModelName"
 
     $headers = @{

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -56,12 +56,22 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
                 $models = $response.data.id | Sort-Object
             }
             'fireworksai' {
-                $account_id = 'fireworks'
+                if ($env:FireworksID) {
+                    $account_id = $env:FireworksID
+                }
+                else {
+                    $account_id = 'fireworks'
+                }
                 $readMask = "readMask=name"
                 $filter = "filter=supports_serverless=true AND supports_tools=true"
                 $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$account_id/models?$readMask&$filter" -Headers @{
                     'Authorization' = "Bearer $env:FireworksAIKey"
                     'Content-Type'  = 'application/json'
+                }
+                # return if no models were found for the specified account_id
+                if (0 -eq $response.totalSize) {
+                    # Display a "no models found" message in the completion results when no models are found for the account_id.
+                    return "No models were returned for account ID: $account_id"
                 }
                 $models = $response.models.name | ForEach-Object { $_ -replace "accounts/$account_id/models/" } | Sort-Object
             }

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -56,7 +56,7 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
                 $models = $response.data.id | Sort-Object
             }
             'fireworksai' {
-                if ($env:FireworksID) {
+                if ($env:FireworksID -match '^[a-zA-Z0-9_-]+$') {
                     $account_id = $env:FireworksID
                 }
                 else {

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -57,7 +57,9 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
             }
             'fireworksai' {
                 $account_id = 'fireworks'
-                $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$account_id/models" -Headers @{
+                $readMask = "readMask=name"
+                $filter = "filter=supports_serverless=true AND supports_tools=true"
+                $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$account_id/models?$readMask&$filter" -Headers @{
                     'Authorization' = "Bearer $env:FireworksAIKey"
                     'Content-Type'  = 'application/json'
                 }

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -1,22 +1,22 @@
 Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName 'Model' -ScriptBlock {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParams)
-   
+
     if ($wordToComplete -notmatch ':') {
-        $completionResults = 'openai', 'google', 'github', 'openrouter', 'anthropic', 'deepseek', 'xAI', 'mistral' | Sort-Object
+        $completionResults = 'openai', 'google', 'github', 'openrouter', 'anthropic', 'deepseek', 'xAI', 'mistral', 'fireworksai' | Sort-Object
         $completionResults | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new("$($_):", $_, 'ParameterValue', "Provider: $_")
         }
-    }    
+    }
     else {
         $provider, $partial = $wordToComplete -split ':', 2
         switch ($provider.ToLower()) {
-            'openai' {                
+            'openai' {
                 $response = Invoke-RestMethod https://api.openai.com/v1/models -Headers @{"Authorization" = "Bearer $env:OPENAIKEY" }
-                $models = $response.data.id                 
+                $models = $response.data.id
             }
             'google' {
                 $response = Invoke-RestMethod https://generativelanguage.googleapis.com/v1beta/models/?key=$env:GEMINIKEY
-                $models = $response.models.name -replace ("models/", "") 
+                $models = $response.models.name -replace ("models/", "")
             }
             'github' {
                 $models = (Invoke-RestMethod https://models.github.ai/catalog/models).id
@@ -31,7 +31,7 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
                 }
                 $models = $response.data.id
             }
-            'deepseek' {                
+            'deepseek' {
                 $response = Invoke-RestMethod https://api.deepseek.com/models -Headers @{
                     "Authorization" = "Bearer $env:DEEPSEEKKEY"
                     "content-type"  = "application/json"
@@ -55,13 +55,21 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
 
                 $models = $response.data.id | Sort-Object
             }
+            'fireworksai' {
+                $account_id = 'fireworks'
+                $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$account_id/models" -Headers @{
+                    'Authorization' = "Bearer $env:FireworksAIKey"
+                    'Content-Type'  = 'application/json'
+                }
+                $models = $response.models.name | ForEach-Object { $_ -replace "accounts/$account_id/models/" } | Sort-Object
+            }
 
             default {
                 Write-Error "Unknown provider: $provider"
                 return
             }
         }
-        
+
         $models | Where-Object { $_ -like "$partial*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new("$($provider):$($_)", "$($provider):$($_)", 'ParameterValue', "Model: $($_)")
         }

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -56,24 +56,44 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
                 $models = $response.data.id | Sort-Object
             }
             'fireworksai' {
-                if ($env:FireworksID -match '^[a-zA-Z0-9_-]+$') {
-                    $account_id = $env:FireworksID
+                if ($env:FireworksID) {
+                    $candidateAccountId = $env:FireworksID.Trim()
+                    if ($candidateAccountId -match '^[a-zA-Z0-9_-]+$') {
+                        $account_id = $candidateAccountId
+                    }
+                    else {
+                        $account_id = 'fireworks'
+                    }
                 }
                 else {
                     $account_id = 'fireworks'
                 }
+                $escaped_account_id = [System.Uri]::EscapeDataString($account_id)
                 $readMask = "readMask=name"
                 $filter = "filter=supports_serverless=true AND supports_tools=true"
-                $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$account_id/models?$readMask&$filter" -Headers @{
+                $response = Invoke-RestMethod "https://api.fireworks.ai/v1/accounts/$escaped_account_id/models?$readMask&$filter" -Headers @{
                     'Authorization' = "Bearer $env:FireworksAIKey"
                     'Content-Type'  = 'application/json'
                 }
                 # return if no models were found for the specified account_id
                 if (0 -eq $response.totalSize) {
-                    # Display a "no models found" message in the completion results when no models are found for the account_id.
-                    return "No models were returned for account ID: $account_id"
+                    $message = "No models were returned for account ID: $account_id"
+                    $toolTip = "$message Check `$env:FireworksID if you expect deployed models for your own account, or remove it to fall back to the default fireworks catalog."
+                    [System.Management.Automation.CompletionResult]::new(
+                        "$wordToComplete ",
+                        '(keep current model text)',
+                        'ParameterValue',
+                        $toolTip
+                    )
+                    [System.Management.Automation.CompletionResult]::new(
+                        "$wordToComplete ",
+                        $message,
+                        'ParameterValue',
+                        $toolTip
+                    )
+                    return
                 }
-                $models = $response.models.name | ForEach-Object { $_ -replace "accounts/$account_id/models/" } | Sort-Object
+                $models = $response.models.name | ForEach-Object { $_ -replace "^accounts/$([regex]::Escape($account_id))/models/" } | Sort-Object
             }
 
             default {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v0.7.0
+
+- Added the `FireworksAI` provider for `Invoke-ChatCompletion`, including tool support and simplified Fireworks model naming.
+- Added FireworksAI model discovery to `-Model` tab completion and documentation for setup and usage.
+- Thank you to Paul Naughton [GitHub](https://github.com/pauljnav) for the FireworksAI provider PR.
+
 # v0.6.0
 
 - OpenAI provider migrated to use the new Responses API endpoint for improved functionality and future compatibility.

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -44,7 +44,7 @@ $model_id = "deepseek-v3p1"
 # Create the model identifier
 $model = "{0}:{1}" -f $provider, $model_id
 $Message = New-ChatMessage -Prompt "Explain Fireworks.ai in one line"
-Invoke-ChatCompletion -Message $Message -Model $model
+Invoke-ChatCompletion -Messages $Message -Model $model
 ```
 
 ---

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -1,0 +1,52 @@
+# FireworksAI
+
+To use FireworksAI with `PSAISuite` you will need to [create an account](https://app.fireworks.ai/account/home/). Once logged in, go to your [API Keys](https://app.fireworks.ai/settings/users/api-keys) page and generate an API key.
+
+Set the following environment variable in your PowerShell session:
+
+```shell
+$env:FireworksAIKey = "your-fireworksai-api-key"
+```
+
+## Deployments
+
+If you have deployed models under your account_id, for PSAISuite to interact with those models, you must also set the following environment variable in your PowerShell session:
+
+```shell
+$env:FireworksID = "your-fireworksai-account_id"
+```
+
+When your account has not deployed any models, the default account_id of "fireworks" is utilized to facilitate access to fireworks default models.
+
+# Tab Completion
+
+The PSAISuite module registers an argument completer that retrieves model names from each provider’s REST API. If no models are found, the completer will indicate this during TAB completion with "No models were returned for account ID: <account_id>". If your account has deployed models but the TAB completer is not returning any model names, verify that your `FireworksID` environment variable is set correctly. As a troubleshooting step, removing this environment variable will cause the default **fireworks** account ID to be used, which should return a set of default models if you have not any models deployed under your own ID.
+
+## Create a Chat Completion
+
+Install `PSAISuite` from the PowerShell Gallery.
+
+```powershell
+Install-Module PSAISuite
+```
+
+In your code:
+
+```powershell
+# Import the module
+Import-Module PSAISuite
+
+$provider = "fireworksai"
+$model_id = "deepseek-v3p1"
+
+# Create the model identifier
+$model = "{0}:{1}" -f $provider, $model_id
+$Message = New-ChatMessage -Prompt "Explain Fireworks.ai in one line"
+Invoke-ChatCompletion -Message $Message -Model $model
+```
+
+---
+
+## See Also
+
+- [PSAISuite Usage Guide](../README.md)

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -22,7 +22,7 @@ When your Fireworks AI account has not deployed any models, the function allows 
 
 # Tab Completion
 
-The PSAISuite module registers an argument completer that retrieves model names from each provider’s REST API. If no models are found, the completer will indicate this during TAB completion with "No models were returned for account ID: <account_id>". If your account has deployed models but the TAB completer is not returning any model names, verify that your `FireworksID` environment variable is set correctly. As a troubleshooting step, removing this environment variable will cause the default **fireworks** account ID to be used, which should return a set of default models if you have not any models deployed under your own ID.
+The PSAISuite module registers an argument completer that retrieves model names from each provider’s REST API. If no models are found, the completer will indicate this during TAB completion with "No models were returned for account ID: <account_id>". If your account has deployed models but the TAB completer is not returning any model names, verify that your `FireworksID` environment variable is set correctly. As a troubleshooting step, removing this environment variable will cause the default **fireworks** account ID to be used, which should return a set of default models if you do not have any models deployed under your own ID.
 
 ## Create a Chat Completion
 

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -10,7 +10,7 @@ $env:FireworksAIKey = "your-fireworksai-api-key"
 
 ## Deployments
 
-If you have deployed models under your account_id, for PSAISuite to interact with those models, you must also reference your FireworksAI account_id. So this by setting the following environment variable in your PowerShell session:
+If you have deployed models under your account_id, for PSAISuite to interact with those models, you must also reference your FireworksAI account_id. Do this by setting the following environment variable in your PowerShell session:
 
 ```shell
 $env:FireworksID = "your-fireworksai-account_id"

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -20,7 +20,7 @@ When your Fireworks AI account has not deployed any models, the function allows 
 
 ---
 
-# Tab Completion
+## Tab Completion
 
 The PSAISuite module registers an argument completer that retrieves model names from each provider’s REST API. If no models are found, the completer will indicate this during TAB completion with "No models were returned for account ID: <account_id>". If your account has deployed models but the TAB completer is not returning any model names, verify that your `FireworksID` environment variable is set correctly. As a troubleshooting step, removing this environment variable will cause the default **fireworks** account ID to be used, which should return a set of default models if you do not have any models deployed under your own ID.
 

--- a/guides/fireworksai.md
+++ b/guides/fireworksai.md
@@ -10,13 +10,15 @@ $env:FireworksAIKey = "your-fireworksai-api-key"
 
 ## Deployments
 
-If you have deployed models under your account_id, for PSAISuite to interact with those models, you must also set the following environment variable in your PowerShell session:
+If you have deployed models under your account_id, for PSAISuite to interact with those models, you must also reference your FireworksAI account_id. So this by setting the following environment variable in your PowerShell session:
 
 ```shell
 $env:FireworksID = "your-fireworksai-account_id"
 ```
 
-When your account has not deployed any models, the default account_id of "fireworks" is utilized to facilitate access to fireworks default models.
+When your Fireworks AI account has not deployed any models, the function allows the `$env:FireworksID` environment variable to be omitted. In this case, the function automatically falls back to the default `account_id` value of `"fireworks"`, enabling access to fireworks default models.
+
+---
 
 # Tab Completion
 


### PR DESCRIPTION
- Adds fireworks.ai provider - implemented with the `$env:FireworksAIKey` pattern.  
Provider supports tools usage, follows toolDefinitions as per the **openai** provider scheme.  
FireworksAI models have a lengthy naming convention `"accounts/$account_id/models/$ModelName"`, this is handled by the provider code to simplify UX.
- Adds to the argument completer - implemented the list-models api with `filter=supports_serverless=true AND supports_tools=true` for an optimised fireworksai models list.
Implementation uses the default 'fireworks' account_id as not supporting end user account_id's.