### PR TITLE
Add Kimi Code provider

### DIFF
--- a/PSAISuite.psd1
+++ b/PSAISuite.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'PSAISuite.psm1'
     
     # Version number of this module.
-    ModuleVersion     = '0.8.1'
+    ModuleVersion     = '0.9.0'
     
     # ID used to uniquely identify this module
     GUID              = 'f5a37b81-6a5a-4b5c-a6e1-2b8a5f9c2fd8'

--- a/Providers/Kimi.ps1
+++ b/Providers/Kimi.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+    Invokes the Kimi Code API to generate responses using specified models.
+
+.DESCRIPTION
+    The Invoke-KimiProvider function sends requests to Kimi Code's OpenAI-compatible
+    chat completions endpoint and returns generated content. It requires an API key
+    in the KIMI_API_KEY environment variable.
+
+.PARAMETER ModelName
+    The Kimi Code model identifier, such as 'k3' or 'kimi-for-coding'.
+
+.PARAMETER Messages
+    An array of hashtables containing the messages to send to the model.
+
+.PARAMETER Tools
+    An array of tool definitions for function calling. Can be strings (command names)
+    or hashtables.
+
+.NOTES
+    Kimi Code requires reasoning_content to be preserved when returning tool results
+    while thinking is enabled. This provider appends the complete assistant message
+    from the API response before sending tool output.
+#>
+function Invoke-KimiProvider {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ModelName,
+
+        [Parameter(Mandatory)]
+        [hashtable[]]$Messages,
+
+        [object[]]$Tools
+    )
+
+    if (-not $env:KIMI_API_KEY) {
+        throw "Kimi Code API key not found. Please set the KIMI_API_KEY environment variable."
+    }
+
+    if ($Tools) {
+        $toolDefinitions = New-Object System.Collections.Generic.List[object]
+        foreach ($tool in $Tools) {
+            if ($tool -is [string]) {
+                $toolDefinitions.Add((Register-Tool $tool))
+            }
+            else {
+                $toolDefinitions.Add($tool)
+            }
+        }
+        $Tools = ConvertTo-ProviderToolSchema -Tools $toolDefinitions -Provider openai
+    }
+
+    $module = Get-Module -Name PSAISuite
+    $moduleVersion = if ($module -and $module.Version) { $module.Version } else { 'unknown' }
+
+    $headers = @{
+        'Authorization' = "Bearer $env:KIMI_API_KEY"
+        'Content-Type'  = 'application/json'
+        'User-Agent'    = "PSAISuite/$moduleVersion"
+    }
+
+    $body = @{
+        model    = $ModelName
+        messages = [hashtable[]]$Messages
+    }
+
+    if ($Tools) {
+        $body['tools'] = $Tools
+    }
+
+    $uri = 'https://api.kimi.com/coding/v1/chat/completions'
+    $maxIterations = 5
+    $iteration = 0
+
+    while ($iteration -lt $maxIterations) {
+        $params = @{
+            Uri     = $uri
+            Method  = 'POST'
+            Headers = $headers
+            Body    = $body | ConvertTo-Json -Depth 10
+        }
+
+        try {
+            $response = Invoke-RestMethod @params
+
+            if ($response.error) {
+                Write-Error $response.error.message
+                return "Error: $($response.error.message)"
+            }
+
+            if (-not $response.choices -or $response.choices.Count -eq 0) {
+                return 'No choices in response from API.'
+            }
+
+            $assistantMessage = $response.choices[0].message
+
+            if ($assistantMessage.tool_calls) {
+                # Preserve every property returned by Kimi, including reasoning_content.
+                $body.messages += $assistantMessage
+
+                foreach ($call in $assistantMessage.tool_calls) {
+                    $functionName = $call.function.name
+                    $functionArgs = @{}
+                    if ($call.function.arguments) {
+                        $functionArgs = $call.function.arguments | ConvertFrom-Json -AsHashtable
+                    }
+
+                    try {
+                        if (Get-Command $functionName -ErrorAction SilentlyContinue) {
+                            $result = & $functionName @functionArgs
+                        }
+                        else {
+                            $result = "Error: Function $functionName not found"
+                        }
+                    }
+                    catch {
+                        $result = "Error: $($_.Exception.Message)"
+                    }
+
+                    $body.messages += @{
+                        role         = 'tool'
+                        tool_call_id = $call.id
+                        content      = $result | Out-String
+                    }
+                }
+            }
+            else {
+                $content = $assistantMessage.content
+                if ($content -is [array]) {
+                    $content = ($content | ForEach-Object { $_.text }) -join ''
+                }
+
+                if (-not $content) {
+                    return 'No text content in response.'
+                }
+
+                return $content
+            }
+        }
+        catch {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            $errorMessage = $_.ErrorDetails.Message
+            Write-Error "Kimi Code API Error (HTTP $statusCode): $errorMessage"
+            return "Error calling Kimi Code API: $($_.Exception.Message)"
+        }
+
+        $iteration++
+    }
+
+    return 'Maximum iterations reached without completing the response.'
+}

--- a/Public/Register-Models.ps1
+++ b/Public/Register-Models.ps1
@@ -13,6 +13,7 @@ $script:ChatCompletionProviders = @{
     fireworksai = @{ Tooltip = 'AI Provider: Fireworks AI' }
     novita      = @{ Tooltip = 'AI Provider: Novita' }
     poe         = @{ Tooltip = 'AI Provider: Poe' }
+    kimi        = @{ Tooltip = 'AI Provider: Kimi Code' }
 }
 
 function ConvertTo-ModelCatalogItem {
@@ -189,6 +190,15 @@ Register-ArgumentCompleter -CommandName 'Invoke-ChatCompletion' -ParameterName '
                 $response = Invoke-RestMethod https://api.poe.com/v1/models -Headers @{
                     "Authorization" = "Bearer $env:PoeKey"
                     "Content-Type"  = "application/json"
+                }
+
+                $models = $response.data | ConvertTo-ModelCatalogItem -Provider $providerKey
+            }
+            'kimi' {
+                $response = Invoke-RestMethod 'https://api.kimi.com/coding/v1/models' -Headers @{
+                    'Authorization' = "Bearer $env:KIMI_API_KEY"
+                    'Content-Type'  = 'application/json'
+                    'User-Agent'    = 'PSAISuite model completion'
                 }
 
                 $models = $response.data | ConvertTo-ModelCatalogItem -Provider $providerKey

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently supported providers are:
 - [Google](guides/google.md)
 - [Groq](guides/groq.md)
 - [Inception](guides/inception.md)
+- [Kimi Code](guides/kimi.md)
 - [Mistral](guides/mistral.md)
 - [Nebius](guides/nebius.md)
 - [Novita](guides/novita.md)
@@ -78,6 +79,7 @@ $env:NebiusKey="your-nebius-api-key"
 $env:GITHUB_TOKEN="your-github-token" # Add GitHub token
 # ... and so on for other providers
 $env:INCEPTION_API_KEY="your-inception-api-key"
+$env:KIMI_API_KEY="your-kimi-code-api-key"
 ```
 
 ### Azure AI Foundry

--- a/__tests__/Kimi.Provider.Tests.ps1
+++ b/__tests__/Kimi.Provider.Tests.ps1
@@ -1,0 +1,152 @@
+BeforeAll {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+    Import-Module "$ProjectRoot\PSAISuite.psd1" -Force
+    $script:PSAISuiteModule = Get-Module PSAISuite
+    $script:OriginalKimiApiKey = $env:KIMI_API_KEY
+}
+
+AfterAll {
+    if ($null -eq $script:OriginalKimiApiKey) {
+        Remove-Item Env:\KIMI_API_KEY -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:KIMI_API_KEY = $script:OriginalKimiApiKey
+    }
+}
+
+Describe 'Kimi provider' {
+    BeforeEach {
+        $env:KIMI_API_KEY = 'test-kimi-key'
+    }
+
+    It 'is available through Get-ChatProviders' {
+        Get-ChatProviders | Should -Contain 'Kimi'
+    }
+
+    It 'sends OpenAI-compatible chat completion requests' {
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            [pscustomobject]@{
+                choices = @(
+                    [pscustomobject]@{
+                        message = [pscustomobject]@{ content = 'Kimi response' }
+                    }
+                )
+            }
+        }
+
+        $result = & $script:PSAISuiteModule {
+            Invoke-KimiProvider -ModelName 'k3' -Messages @(@{ role = 'user'; content = 'Hello Kimi' })
+        }
+
+        $result | Should -Be 'Kimi response'
+        Assert-MockCalled -ModuleName PSAISuite Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -eq 'https://api.kimi.com/coding/v1/chat/completions' -and
+            $Method -eq 'POST' -and
+            $Headers.Authorization -eq 'Bearer test-kimi-key' -and
+            $Headers.'Content-Type' -eq 'application/json' -and
+            $Headers.'User-Agent' -match '^PSAISuite/' -and
+            ($Body | ConvertFrom-Json).model -eq 'k3'
+        }
+    }
+
+    It 'requires KIMI_API_KEY' {
+        Remove-Item Env:\KIMI_API_KEY -ErrorAction SilentlyContinue
+
+        {
+            & $script:PSAISuiteModule {
+                Invoke-KimiProvider -ModelName 'k3' -Messages @(@{ role = 'user'; content = 'Hello Kimi' })
+            }
+        } | Should -Throw 'Kimi Code API key not found. Please set the KIMI_API_KEY environment variable.'
+    }
+
+    It 'preserves reasoning content when continuing after a tool call' {
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            param($Body)
+
+            if ($Body -match 'reasoning_content') {
+                return [pscustomobject]@{
+                    choices = @(
+                        [pscustomobject]@{
+                            message = [pscustomobject]@{ content = 'Tool result received' }
+                        }
+                    )
+                }
+            }
+
+            [pscustomobject]@{
+                choices = @(
+                    [pscustomobject]@{
+                        message = [pscustomobject]@{
+                            content = $null
+                            reasoning_content = 'I need to call a tool before answering.'
+                            tool_calls = @(
+                                [pscustomobject]@{
+                                    id = 'call_kimi_1'
+                                    type = 'function'
+                                    function = [pscustomobject]@{
+                                        name = 'Get-MissingKimiTestTool'
+                                        arguments = '{}'
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        $tool = @{
+            Name = 'Get-MissingKimiTestTool'
+            Description = 'Test-only tool schema.'
+            Parameters = @{ type = 'object'; properties = @{} }
+        }
+
+        $result = & $script:PSAISuiteModule {
+            param($toolDefinition)
+            Invoke-KimiProvider -ModelName 'kimi-for-coding' -Messages @(@{ role = 'user'; content = 'Use a tool.' }) -Tools $toolDefinition
+        } $tool
+
+        $result | Should -Be 'Tool result received'
+        Assert-MockCalled -ModuleName PSAISuite Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body -match 'reasoning_content' -and
+            $Body -match 'call_kimi_1' -and
+            $Body -match 'tool_call_id'
+        }
+    }
+
+    It 'returns no choices when the API response is empty' {
+        Mock -ModuleName PSAISuite Invoke-RestMethod { [pscustomobject]@{ choices = @() } }
+
+        $result = & $script:PSAISuiteModule {
+            Invoke-KimiProvider -ModelName 'kimi-for-coding' -Messages @(@{ role = 'user'; content = 'Hello Kimi' })
+        }
+
+        $result | Should -Be 'No choices in response from API.'
+    }
+}
+
+Describe 'Kimi model completion' {
+    BeforeEach {
+        $env:KIMI_API_KEY = 'test-kimi-key'
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            [pscustomobject]@{
+                data = @(
+                    [pscustomobject]@{ id = 'k3'; owned_by = 'kimi' },
+                    [pscustomobject]@{ id = 'kimi-for-coding'; owned_by = 'kimi' }
+                )
+            }
+        }
+    }
+
+    It 'retrieves Kimi models from the authenticated models endpoint' {
+        $inputScript = 'Invoke-ChatCompletion -Model kimi:'
+        $result = TabExpansion2 -InputScript $inputScript -CursorColumn $inputScript.Length
+
+        $result.CompletionMatches.CompletionText | Should -Contain 'kimi:k3'
+        $result.CompletionMatches.CompletionText | Should -Contain 'kimi:kimi-for-coding'
+        Assert-MockCalled -ModuleName PSAISuite Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -eq 'https://api.kimi.com/coding/v1/models' -and
+            $Headers.Authorization -eq 'Bearer test-kimi-key'
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v0.9.0
+
+- Added the Kimi Code provider for `Invoke-ChatCompletion` using Kimi's OpenAI-compatible API.
+- Added Kimi Code model discovery for `-Model` tab completion and tool-calling support that preserves Kimi reasoning context.
+- Added Kimi Code setup and usage documentation.
+
 # v0.8.1
 
 - Thank you to Paul Naughton [GitHub](https://github.com/pauljnav) for the model tooltip and Anthropic documentation fixes PR.

--- a/changelog.md
+++ b/changelog.md
@@ -63,7 +63,7 @@
     - Uses max_completion_tokens and removes unsupported parameters; clearer error messages.
 - Argument completer:
     - Expanded live model completion for providers: openai, google, github, openrouter, anthropic, deepseek, xai, mistral.
-- Misc: small documentation touch-ups and provider consistency fixes.
+- Misc.: small documentation touch-ups and provider consistency fixes.
 
 # v0.5.1
 

--- a/guides/kimi.md
+++ b/guides/kimi.md
@@ -1,0 +1,64 @@
+# Kimi Code
+
+To use Kimi Code with `PSAISuite`, you need an active Kimi membership with Kimi Code benefits. Create an API key in the [Kimi Code Console](https://www.kimi.com/code) and set it for your PowerShell session:
+
+```powershell
+$env:KIMI_API_KEY = "your-kimi-code-api-key"
+```
+
+Kimi Code and the pay-as-you-go Kimi Platform use different API keys and endpoints. This provider uses Kimi Code's subscription-backed endpoint, so use a key created in the Kimi Code Console.
+
+## Create a Chat Completion
+
+Install `PSAISuite` from the PowerShell Gallery:
+
+```powershell
+Install-Module PSAISuite
+```
+
+Then invoke a Kimi Code model:
+
+```powershell
+Import-Module PSAISuite
+
+Invoke-ChatCompletion -Messages "Write a PowerShell function that tests whether a number is prime." -Model "kimi:kimi-for-coding"
+```
+
+## Available Models
+
+Use tab completion after typing `kimi:` to retrieve the models available to your Kimi Code subscription. Kimi currently documents these model IDs:
+
+- `k3` — Kimi K3; requires an eligible membership tier.
+- `kimi-for-coding` — Kimi K2.7 Code; available to Kimi Code members.
+- `kimi-for-coding-highspeed` — accelerated K2.7 Code; requires an eligible membership tier.
+
+For example:
+
+```powershell
+Invoke-ChatCompletion -Messages "Review this function for edge cases." -Model "kimi:k3"
+```
+
+## Tool Calling
+
+Kimi Code supports the existing `-Tools` interface, including custom tool schemas:
+
+```powershell
+$tool = @{
+    Name = 'Get-Weather'
+    Description = 'Gets the current weather for a location.'
+    Parameters = @{
+        type = 'object'
+        properties = @{ location = @{ type = 'string' } }
+        required = @('location')
+    }
+}
+
+Invoke-ChatCompletion -Messages "What is the weather in Boston?" -Tools $tool -Model "kimi:kimi-for-coding"
+```
+
+Kimi Code keeps thinking enabled for its coding models. PSAISuite preserves Kimi's reasoning context automatically when the model requests a tool.
+
+## See Also
+
+- [Kimi Code documentation](https://www.kimi.com/code/docs/en/)
+- [PSAISuite Usage Guide](../README.md)


### PR DESCRIPTION
## Summary

- add Kimi Code as an OpenAI-compatible PSAISuite provider
- retrieve subscription-available Kimi models for `-Model` completion
- preserve Kimi reasoning context through tool-call continuations
- document setup and add provider-focused tests

## Validation

- `Invoke-Pester -Path .\__tests__` (44 passed)
- `Invoke-ScriptAnalyzer` on the new provider and tests