### PR TITLE
fix OpenAI instruction handling for 0.8.5

### DIFF
--- a/PSAISuite.psd1
+++ b/PSAISuite.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'PSAISuite.psm1'
     
     # Version number of this module.
-    ModuleVersion     = '0.8.2'
+    ModuleVersion     = '0.8.5'
     
     # ID used to uniquely identify this module
     GUID              = 'f5a37b81-6a5a-4b5c-a6e1-2b8a5f9c2fd8'

--- a/Providers/OpenAI.ps1
+++ b/Providers/OpenAI.ps1
@@ -15,6 +15,9 @@
 .PARAMETER Tools
     An array of tool definitions for function calling. Can be strings (command names) or hashtables.
 
+.PARAMETER MaxIterations
+    The maximum number of Responses API tool-calling rounds allowed before the request stops.
+
 .PARAMETER EffortLevel
     The requested OpenAI reasoning effort level. Supported values are model-dependent.
 
@@ -33,6 +36,289 @@
     Uses OpenAI's Responses API for all models.
     API Reference: https://platform.openai.com/docs/api-reference/responses
 #>
+
+function Get-OpenAIProjectInstructionFiles {
+    param(
+        [string]$StartingDirectory = (Get-Location).Path
+    )
+
+    try {
+        $startingDirectoryItem = Get-Item -LiteralPath $StartingDirectory -ErrorAction Stop
+    }
+    catch {
+        Write-Verbose "[$((Get-Date).ToString('o'))] Unable to inspect project instructions from '$StartingDirectory': $($_.Exception.Message)"
+        return @()
+    }
+
+    $ancestors = New-Object 'System.Collections.Generic.List[System.IO.DirectoryInfo]'
+    $currentDirectory = $startingDirectoryItem
+    $projectRootIndex = -1
+
+    while ($null -ne $currentDirectory) {
+        [void]$ancestors.Add($currentDirectory)
+
+        if (Test-Path -LiteralPath (Join-Path $currentDirectory.FullName '.git')) {
+            $projectRootIndex = $ancestors.Count - 1
+            break
+        }
+
+        $parentDirectory = $currentDirectory.Parent
+        if ($null -eq $parentDirectory -or $parentDirectory.FullName -eq $currentDirectory.FullName) {
+            break
+        }
+
+        $currentDirectory = $parentDirectory
+    }
+
+    # Without a project marker, only the current directory is in scope.
+    if ($projectRootIndex -lt 0) {
+        $projectRootIndex = 0
+    }
+
+    $instructionFiles = @()
+    for ($index = $projectRootIndex; $index -ge 0; $index--) {
+        $instructionPath = Join-Path $ancestors[$index].FullName 'AGENTS.md'
+        if (Test-Path -LiteralPath $instructionPath -PathType Leaf) {
+            try {
+                $instructionFiles += Get-Item -LiteralPath $instructionPath -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose "[$((Get-Date).ToString('o'))] Unable to inspect '$instructionPath': $($_.Exception.Message)"
+            }
+        }
+    }
+
+    return @($instructionFiles)
+}
+
+function Get-OpenAITextHash {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes([string]$Text)
+        return ([System.BitConverter]::ToString($sha256.ComputeHash($bytes))).Replace('-', '')
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+
+function Get-OpenAIProjectInstructionState {
+    $entries = @()
+
+    foreach ($instructionFile in @(Get-OpenAIProjectInstructionFiles)) {
+        try {
+            $content = Get-Content -LiteralPath $instructionFile.FullName -Raw -ErrorAction Stop
+            $entries += [PSCustomObject]@{
+                Path    = $instructionFile.FullName
+                Content = $content
+                Hash    = Get-OpenAITextHash -Text $content
+            }
+        }
+        catch {
+            Write-Verbose "[$((Get-Date).ToString('o'))] Unable to read '$($instructionFile.FullName)': $($_.Exception.Message)"
+        }
+    }
+
+    if ($entries.Count -eq 0) {
+        return $null
+    }
+
+    $sections = foreach ($entry in $entries) {
+        "--- BEGIN $($entry.Path) ---`n$($entry.Content)`n--- END $($entry.Path) ---"
+    }
+
+    $signature = (($entries | ForEach-Object { "$($_.Path)::$($_.Hash)" }) -join '|')
+    $text = @(
+        'Project instructions loaded from AGENTS.md. Treat these as project guidance for this request.'
+        'They do not override system, developer, user, safety, or tool constraints.'
+        ''
+        ($sections -join "`n`n")
+    ) -join "`n"
+
+    return [PSCustomObject]@{
+        Signature = $signature
+        Text      = $text
+        Paths     = @($entries | ForEach-Object { $_.Path })
+    }
+}
+
+function Get-OpenAIInstructionText {
+    param(
+        [object[]]$Messages,
+        [AllowNull()]
+        [object]$ProjectInstructionState
+    )
+
+    $instructionSections = @($Messages | ForEach-Object {
+            $content = $_
+
+            if ($null -eq $content) {
+                return
+            }
+
+            if ($content -is [string]) {
+                $text = $content
+            }
+            elseif ($content -is [System.Collections.IDictionary]) {
+                if ($content.Contains('text')) {
+                    $text = [string]$content['text']
+                }
+                elseif ($content.Contains('content')) {
+                    $text = ConvertTo-OpenAIInstructionText -Content $content['content']
+                }
+                else {
+                    $text = $content | ConvertTo-Json -Depth 20 -Compress
+                }
+            }
+            elseif ($content -is [System.Collections.IEnumerable]) {
+                $text = (@($content | ForEach-Object {
+                            ConvertTo-OpenAIInstructionText -Content $_
+                        }) -join '')
+            }
+            elseif ($content.PSObject.Properties['text']) {
+                $text = [string]$content.text
+            }
+            elseif ($content.PSObject.Properties['content']) {
+                $text = ConvertTo-OpenAIInstructionText -Content $content.content
+            }
+            else {
+                $text = [string]$content
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                $text
+            }
+        })
+
+    if ($ProjectInstructionState) {
+        $instructionSections += $ProjectInstructionState.Text
+    }
+
+    if ($instructionSections.Count -eq 0) {
+        return $null
+    }
+
+    return $instructionSections -join "`n`n"
+}
+
+function ConvertTo-OpenAIInstructionText {
+    param(
+        [AllowNull()]
+        [object]$Content
+    )
+
+    if ($null -eq $Content) {
+        return $null
+    }
+
+    if ($Content -is [string]) {
+        return $Content
+    }
+
+    if ($Content -is [System.Collections.IDictionary]) {
+        if ($Content.Contains('text')) {
+            return [string]$Content['text']
+        }
+
+        if ($Content.Contains('content')) {
+            return ConvertTo-OpenAIInstructionText -Content $Content['content']
+        }
+
+        return $Content | ConvertTo-Json -Depth 20 -Compress
+    }
+
+    if ($Content -is [System.Collections.IEnumerable]) {
+        return (@($Content | ForEach-Object {
+                    ConvertTo-OpenAIInstructionText -Content $_
+                }) -join '')
+    }
+
+    if ($Content.PSObject.Properties['text']) {
+        return [string]$Content.text
+    }
+
+    if ($Content.PSObject.Properties['content']) {
+        return ConvertTo-OpenAIInstructionText -Content $Content.content
+    }
+
+    return [string]$Content
+}
+
+function Write-OpenAIActivity {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+        [int]$Iteration,
+        [int]$MaxIterations
+    )
+
+    $timestampedMessage = "[$((Get-Date).ToString('o'))] $Message"
+    Write-Verbose $timestampedMessage
+
+    $percentComplete = 0
+    if ($MaxIterations -gt 0) {
+        $percentComplete = [Math]::Min(99, [Math]::Max(0, [int](($Iteration / $MaxIterations) * 100)))
+    }
+
+    Write-Progress `
+        -Id 9173 `
+        -Activity 'OpenAI tool workflow' `
+        -Status $timestampedMessage `
+        -PercentComplete $percentComplete
+}
+
+function Complete-OpenAIActivity {
+    Write-Progress -Id 9173 -Activity 'OpenAI tool workflow' -Completed
+}
+
+function Invoke-OpenAITool {
+    param(
+        [Parameter(Mandatory)]
+        [string]$FunctionName,
+        [hashtable]$FunctionArgs = @{}
+    )
+
+    try {
+        if (-not (Get-Command $FunctionName -ErrorAction SilentlyContinue)) {
+            return "Error: Function $FunctionName not found"
+        }
+
+        # Redirect the error stream so non-terminating PowerShell errors are sent
+        # back to the model as tool output instead of only being shown to the user.
+        $toolOutput = @(& $FunctionName @FunctionArgs 2>&1)
+        $toolErrors = @($toolOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })
+        $toolValues = @($toolOutput | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] })
+
+        if ($toolErrors.Count -gt 0) {
+            $errorText = ($toolErrors | ForEach-Object {
+                    if ($_.Exception -and $_.Exception.Message) { $_.Exception.Message }
+                    else { $_ | Out-String }
+                }) -join '; '
+            $result = "Error executing $FunctionName`: $errorText"
+
+            if ($toolValues.Count -gt 0) {
+                $result += "`nPartial output:`n$($toolValues | Out-String)"
+            }
+
+            return $result.TrimEnd()
+        }
+
+        if ($toolOutput.Count -eq 0) {
+            return '(no output)'
+        }
+
+        return ($toolOutput | Out-String).TrimEnd()
+    }
+    catch {
+        return "Error executing $FunctionName`: $($_.Exception.Message)"
+    }
+}
+
 function Invoke-OpenAIProvider {
     param(
         [Parameter(Mandatory)]
@@ -40,6 +326,8 @@ function Invoke-OpenAIProvider {
         [Parameter(Mandatory)]
         [hashtable[]]$Messages,
         [object[]]$Tools,
+        [ValidateRange(1, 100)]
+        [int]$MaxIterations = 5,
         [ValidateSet('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max')]
         [string]$EffortLevel,
         [ValidateSet('auto', 'default', 'flex', 'fast', 'priority')]
@@ -68,9 +356,26 @@ function Invoke-OpenAIProvider {
     
     $Uri = "https://api.openai.com/v1/responses"
     
+    $projectInstructionState = Get-OpenAIProjectInstructionState
+    $messageInstructions = @(
+        $Messages |
+            Where-Object { $_.role -eq 'system' -or $_.role -eq 'developer' } |
+            ForEach-Object { $_.content }
+    )
+    $inputMessages = @($Messages | Where-Object { $_.role -ne 'system' -and $_.role -ne 'developer' })
+
     $body = @{
         'model' = $ModelName
-        'input' = $Messages
+        'input' = $inputMessages
+    }
+
+    $instructionText = Get-OpenAIInstructionText -Messages $messageInstructions -ProjectInstructionState $projectInstructionState
+    if ($instructionText) {
+        $body['instructions'] = $instructionText
+    }
+
+    if ($projectInstructionState) {
+        Write-Verbose "[$((Get-Date).ToString('o'))] Loaded AGENTS.md: $($projectInstructionState.Paths -join ', ')"
     }
 
     if ($EffortLevel) {
@@ -95,10 +400,12 @@ function Invoke-OpenAIProvider {
             })
     }
     
-    $maxIterations = 5
     $iteration = 0
     
-    while ($iteration -lt $maxIterations) {
+    while ($iteration -lt $MaxIterations) {
+        $round = $iteration + 1
+        Write-OpenAIActivity -Message "Request started (round $round/$MaxIterations)" -Iteration $iteration -MaxIterations $MaxIterations
+
         $params = @{
             Uri     = $Uri
             Method  = 'POST'
@@ -111,12 +418,14 @@ function Invoke-OpenAIProvider {
             
             # Check if the response contains an error
             if ($response.error) {
+                Complete-OpenAIActivity
                 Write-Error $response.error.message
                 return "Error: $($response.error.message)"
             }
             
             # Check if output exists
             if (!$response.output) {
+                Complete-OpenAIActivity
                 return "No output in response from API."
             }
             
@@ -124,30 +433,64 @@ function Invoke-OpenAIProvider {
             $functionCalls = $response.output | Where-Object { $_.type -eq 'function_call' }
             
             if ($functionCalls) {
+                Write-OpenAIActivity -Message "Model requested $(@($functionCalls).Count) tool call(s)" -Iteration $iteration -MaxIterations $MaxIterations
+
                 # Add all response output items to the input for context
                 $body.input += $response.output
                 
                 # Execute function calls and add results
                 foreach ($call in $functionCalls) {
                     $functionName = $call.name
-                    $functionArgs = $call.arguments | ConvertFrom-Json -AsHashtable
-                    
+                    $toolStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                    Write-OpenAIActivity -Message "Tool started: $functionName" -Iteration $iteration -MaxIterations $MaxIterations
+
                     try {
-                        if (Get-Command $functionName -ErrorAction SilentlyContinue) {
-                            $result = & $functionName @functionArgs
+                        $functionArgs = if ($call.arguments) {
+                            $call.arguments | ConvertFrom-Json -AsHashtable
                         }
                         else {
-                            $result = "Error: Function $functionName not found"
+                            @{}
                         }
+
+                        $result = Invoke-OpenAITool -FunctionName $functionName -FunctionArgs $functionArgs
                     }
                     catch {
-                        $result = "Error: $($_.Exception.Message)"
+                        $result = "Error executing $FunctionName`: $($_.Exception.Message)"
                     }
+
+                    $toolStopwatch.Stop()
+                    Write-OpenAIActivity -Message "Tool completed: $functionName ($($toolStopwatch.ElapsedMilliseconds) ms)" -Iteration $iteration -MaxIterations $MaxIterations
                     
                     $body.input += @{
                         type    = 'function_call_output'
                         call_id = $call.call_id
-                        output  = $result | Out-String
+                        output  = $result
+                    }
+                }
+
+                $updatedProjectInstructionState = Get-OpenAIProjectInstructionState
+                $instructionsChanged = if ($null -eq $projectInstructionState) {
+                    $null -ne $updatedProjectInstructionState
+                }
+                else {
+                    $null -eq $updatedProjectInstructionState -or $updatedProjectInstructionState.Signature -ne $projectInstructionState.Signature
+                }
+
+                if ($instructionsChanged) {
+                    $projectInstructionState = $updatedProjectInstructionState
+                    $updatedInstructionText = Get-OpenAIInstructionText -Messages $messageInstructions -ProjectInstructionState $projectInstructionState
+                    if ($updatedInstructionText) {
+                        $body['instructions'] = $updatedInstructionText
+                    }
+                    else {
+                        [void]$body.Remove('instructions')
+                    }
+
+                    if ($updatedProjectInstructionState) {
+                        Write-OpenAIActivity -Message "AGENTS.md discovered or changed; loaded for next request" -Iteration $iteration -MaxIterations $MaxIterations
+                    }
+                    else {
+                        Write-OpenAIActivity -Message 'AGENTS.md was removed; updated context for next request' -Iteration $iteration -MaxIterations $MaxIterations
                     }
                 }
             }
@@ -161,12 +504,16 @@ function Invoke-OpenAIProvider {
                         elseif ($_.content) {
                             $_.content
                         }
-                    }) -join ''
+                }) -join ''
                 if (!$textOutput) {
+                    Complete-OpenAIActivity
                     return "No text content in response."
                 }
+                Write-OpenAIActivity -Message "Response completed (round $round/$MaxIterations)" -Iteration $MaxIterations -MaxIterations $MaxIterations
+                Complete-OpenAIActivity
                 return [PSCustomObject]@{
                     Text                   = $textOutput
+                    MaxIterations          = $MaxIterations
                     RequestedEffortLevel   = $EffortLevel
                     RequestedSpeedLevel    = $SpeedLevel
                     ReasoningEffort        = if ($response.reasoning) { $response.reasoning.effort } else { $null }
@@ -175,6 +522,7 @@ function Invoke-OpenAIProvider {
             }
         }
         catch {
+            Complete-OpenAIActivity
             $statusCode = $_.Exception.Response.StatusCode.value__
             $errorMessage = $_.ErrorDetails.Message
             Write-Error "OpenAI API Error (HTTP $statusCode): $errorMessage"
@@ -183,6 +531,7 @@ function Invoke-OpenAIProvider {
         
         $iteration++
     }
-    
-    return "Maximum iterations reached without completing the response."
+
+    Complete-OpenAIActivity
+    return "Maximum iterations reached without completing the response after $MaxIterations iterations."
 }

--- a/Public/Invoke-ChatCompletion.ps1
+++ b/Public/Invoke-ChatCompletion.ps1
@@ -24,6 +24,11 @@ An array of tool definitions for function calling. Can be:
 - Array of strings (command names) that will be registered as tools
 - Array of hashtables (already defined tool schemas)
 
+.PARAMETER MaxIterations
+The maximum number of OpenAI Responses API tool-calling rounds allowed before
+the request stops. This parameter is currently supported only when using the
+OpenAI provider and defaults to 5.
+
 .PARAMETER EffortLevel
 The OpenAI reasoning effort level. Supported values are model-dependent. This
 parameter is currently supported only when using the OpenAI provider.
@@ -100,6 +105,9 @@ function Invoke-ChatCompletion {
         [object]$Context,
 
         [object[]]$Tools,
+
+        [ValidateRange(1, 100)]
+        [int]$MaxIterations = 5,
 
         [ValidateSet('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max')]
         [string]$EffortLevel,
@@ -180,6 +188,10 @@ function Invoke-ChatCompletion {
             throw "Model must be specified in 'provider:model' format."
         }
 
+        if ($PSBoundParameters.ContainsKey('MaxIterations') -and $provider -ne 'openai') {
+            throw "MaxIterations is currently supported only for the OpenAI provider."
+        }
+
         if (($EffortLevel -or $SpeedLevel) -and $provider -ne 'openai') {
             throw "EffortLevel and SpeedLevel are currently supported only for the OpenAI provider."
         }
@@ -204,6 +216,8 @@ function Invoke-ChatCompletion {
         }
 
         if ($provider -eq 'openai') {
+            $functionParams.MaxIterations = $MaxIterations
+
             if ($EffortLevel) {
                 $functionParams.EffortLevel = $EffortLevel
             }
@@ -211,10 +225,6 @@ function Invoke-ChatCompletion {
             if ($SpeedLevel) {
                 $functionParams.SpeedLevel = $SpeedLevel
             }
-        }
-
-        if ($SystemRole) {
-            $functionParams.SystemRole = $SystemRole
         }
 
         $providerResult = & $providerFunction @functionParams
@@ -243,6 +253,7 @@ function Invoke-ChatCompletion {
         }
 
         if ($providerMetadata) {
+            $responseObject | Add-Member -MemberType NoteProperty -Name 'MaxIterations' -Value $providerMetadata.MaxIterations
             $responseObject | Add-Member -MemberType NoteProperty -Name 'EffortLevel' -Value $providerMetadata.RequestedEffortLevel
             $responseObject | Add-Member -MemberType NoteProperty -Name 'SpeedLevel' -Value $providerMetadata.RequestedSpeedLevel
             $responseObject | Add-Member -MemberType NoteProperty -Name 'ReasoningEffort' -Value $providerMetadata.ReasoningEffort
@@ -251,10 +262,6 @@ function Invoke-ChatCompletion {
 
         if ($IncludeElapsedTime) {
             $responseObject | Add-Member -MemberType NoteProperty -Name 'ElapsedTime' -Value $elapsedTime
-        }
-
-        if ($SystemRole) {
-            $responseObject | Add-Member -MemberType NoteProperty -Name 'SystemRole' -Value $SystemRole
         }
 
         if ($Raw) {

--- a/README.md
+++ b/README.md
@@ -168,6 +168,38 @@ Invoke-ChatCompletion -Messages "What's the weather in New York?" -Tools $custom
 
 Currently, tool calling is supported for the OpenAI, xAI, Anthropic, and Google providers. Support for other providers will be added in future updates.
 
+### OpenAI instructions and tool workflows
+
+OpenAI system and developer messages are sent as Responses API instructions and
+remain available across tool-calling rounds. Structured text content is
+supported as well:
+
+```powershell
+$messages = @(
+    @{ role = 'system'; content = @(@{ type = 'input_text'; text = 'Use standard Markdown links.' }) }
+    @{ role = 'developer'; content = 'Keep the response concise.' }
+    @{ role = 'user'; content = 'Create an index of the project.' }
+)
+
+Invoke-ChatCompletion -Messages $messages -Model 'openai:gpt-5.6'
+```
+
+For OpenAI tool workflows, `-MaxIterations` controls the maximum number of
+tool-calling rounds and defaults to 5:
+
+```powershell
+Invoke-ChatCompletion `
+    -Messages 'Find the files and summarize their contents.' `
+    -Model 'openai:gpt-5.6' `
+    -Tools 'Get-ChildItem' `
+    -MaxIterations 10
+```
+
+OpenAI effort values are model-dependent. The accepted values are `none`,
+`minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. When an `AGENTS.md`
+file is present in the current project path or one of its project ancestors,
+it is loaded as project guidance and refreshed between tool rounds.
+
 Using `PSAISuite` to generate chat completion responses from different providers.
 
 ### List Available Providers

--- a/__tests__/Invoke-ChatCompletion.Tests.ps1
+++ b/__tests__/Invoke-ChatCompletion.Tests.ps1
@@ -38,8 +38,8 @@ Describe "Invoke-ChatCompletion" {
             $commonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
             $filteredParameters = $parameters | Where-Object { $commonParameters -notcontains $_.Name }
 
-            $filteredParameters.Count | Should -Be 8
-            $filteredParameters.Name | Should -Be @("Messages", "Model", "Context", "Tools", "EffortLevel", "SpeedLevel", "IncludeElapsedTime", "Raw")
+            $filteredParameters.Count | Should -Be 9
+            $filteredParameters.Name | Should -Be @("Messages", "Model", "Context", "Tools", "MaxIterations", "EffortLevel", "SpeedLevel", "IncludeElapsedTime", "Raw")
         }
 
         It "Should test Context parameter is valueFromPipeline" {
@@ -51,6 +51,18 @@ Describe "Invoke-ChatCompletion" {
         It "Should accept Tools parameter" {
             $actual = (Get-Command Invoke-ChatCompletion)
             $actual.Parameters.Tools | Should -Not -BeNullOrEmpty
+        }
+
+        It "Exposes the supported OpenAI reasoning effort levels" {
+            $effortParameter = (Get-Command Invoke-ChatCompletion).Parameters['EffortLevel']
+            $validateSet = $effortParameter.Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+
+            @($validateSet.ValidValues) | Should -Be @('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max')
+        }
+
+        It "Rejects effort levels that are not supported by OpenAI" {
+            { Invoke-ChatCompletion -Messages "Test prompt" -EffortLevel ultrafast } | Should -Throw
         }
     }
 
@@ -124,6 +136,19 @@ Describe "Invoke-ChatCompletion" {
             $result.ReasoningEffort | Should -Be "low"
             $result.ServiceTier | Should -Be "priority"
         }
+
+        It "Passes OpenAI max iterations to the provider" {
+            $global:capturedMaxIterations = $null
+            Mock -ModuleName PSAISuite Invoke-OpenAIProvider {
+                param($ModelName, $Messages, $MaxIterations)
+                $global:capturedMaxIterations = $MaxIterations
+                [PSCustomObject]@{ Text = "OpenAI response" }
+            }
+
+            Invoke-ChatCompletion -Messages "Test prompt" -Model "openai:gpt-5.6" -MaxIterations 12 | Out-Null
+
+            $global:capturedMaxIterations | Should -Be 12
+        }
     }
 
     Context "String input handling" {
@@ -181,6 +206,12 @@ Describe "Invoke-ChatCompletion" {
             $message = New-ChatMessage -Prompt "Test"
             { Invoke-ChatCompletion -Messages $message -Model "anthropic:claude-3-sonnet-20240229" -EffortLevel low } |
             Should -Throw "EffortLevel and SpeedLevel are currently supported only for the OpenAI provider."
+        }
+
+        It "Rejects OpenAI max iterations for other providers" {
+            $message = New-ChatMessage -Prompt "Test"
+            { Invoke-ChatCompletion -Messages $message -Model "anthropic:claude-3-sonnet-20240229" -MaxIterations 12 } |
+            Should -Throw "MaxIterations is currently supported only for the OpenAI provider."
         }
     }
 
@@ -275,5 +306,250 @@ Describe "Invoke-OpenAIProvider effort and speed options" {
             $result.ReasoningEffort | Should -Be 'low'
             $result.ServiceTier | Should -Be 'priority'
         }
+    }
+}
+
+Describe "Invoke-OpenAIProvider max iterations" {
+    BeforeEach {
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            [PSCustomObject]@{
+                output = @(
+                    [PSCustomObject]@{
+                        type      = 'function_call'
+                        name      = 'Missing-Test-Tool'
+                        arguments = '{}'
+                        call_id   = 'call-1'
+                    }
+                )
+            }
+        }
+    }
+
+    It "stops after the configured number of tool-calling rounds" {
+        InModuleScope PSAISuite {
+            $result = Invoke-OpenAIProvider -ModelName 'gpt-5.6' -Messages @(@{ role = 'user'; content = 'Use a tool' }) -MaxIterations 2
+
+            $result | Should -Be 'Maximum iterations reached without completing the response after 2 iterations.'
+        }
+    }
+}
+
+Describe "Invoke-OpenAIProvider tool feedback and project instructions" {
+    BeforeEach {
+        Mock -ModuleName PSAISuite Write-Progress {}
+    }
+
+    It "returns non-terminating PowerShell tool errors to the model" {
+        $global:openAIRequestCount = 0
+        $global:capturedToolOutput = $null
+        $global:missingToolPath = Join-Path $TestDrive 'missing-file.md'
+        $global:toolFeedbackTestTool = @{
+            Name        = 'Get-Content'
+            Description = 'Reads a file.'
+            Parameters  = @{
+                type       = 'object'
+                properties = @{ Path = @{ type = 'string' } }
+                required   = @('Path')
+            }
+        }
+
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            $global:openAIRequestCount++
+            $request = $Body | ConvertFrom-Json
+
+            if ($global:openAIRequestCount -eq 1) {
+                return [PSCustomObject]@{
+                    output = @(
+                        [PSCustomObject]@{
+                            type      = 'function_call'
+                            name      = 'Get-Content'
+                            arguments = (@{ Path = $global:missingToolPath } | ConvertTo-Json -Compress)
+                            call_id   = 'call-error-1'
+                        }
+                    )
+                }
+            }
+
+            $global:capturedToolOutput = @($request.input | Where-Object { $_.type -eq 'function_call_output' } | Select-Object -Last 1).output
+            [PSCustomObject]@{
+                output = @(
+                    [PSCustomObject]@{
+                        type    = 'message'
+                        content = @([PSCustomObject]@{ type = 'output_text'; text = 'I received the tool error.' })
+                    }
+                )
+            }
+        }
+
+        InModuleScope PSAISuite {
+            $global:toolFeedbackTestResult = Invoke-OpenAIProvider -ModelName 'gpt-5.6' -Messages @(@{ role = 'user'; content = 'Read the file' }) -Tools $global:toolFeedbackTestTool
+        }
+
+        $global:toolFeedbackTestResult.Text | Should -Be 'I received the tool error.'
+        $global:capturedToolOutput | Should -Match 'Error executing Get-Content'
+        $global:capturedToolOutput | Should -Match 'missing-file.md'
+    }
+
+    It "loads an AGENTS.md file created during a tool round" {
+        $global:openAIRequestCount = 0
+        $global:secondRequestInput = $null
+        $global:secondRequestInstructions = $null
+        $global:agentsTestPath = Join-Path $TestDrive 'AGENTS.md'
+
+        function global:New-PSAISuiteTestAgentsFile {
+            param([string]$Path)
+            Set-Content -LiteralPath $Path -Value '# Test project instructions`nUse the project instructions.'
+            return 'AGENTS.md created'
+        }
+
+        $global:agentsTestTool = @{
+            Name        = 'New-PSAISuiteTestAgentsFile'
+            Description = 'Creates the project instruction file.'
+            Parameters  = @{
+                type       = 'object'
+                properties = @{ Path = @{ type = 'string' } }
+                required   = @('Path')
+            }
+        }
+
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            $global:openAIRequestCount++
+            $request = $Body | ConvertFrom-Json
+
+            if ($global:openAIRequestCount -eq 1) {
+                return [PSCustomObject]@{
+                    output = @(
+                        [PSCustomObject]@{
+                            type      = 'function_call'
+                            name      = 'New-PSAISuiteTestAgentsFile'
+                            arguments = (@{ Path = $global:agentsTestPath } | ConvertTo-Json -Compress)
+                            call_id   = 'call-agents-1'
+                        }
+                    )
+                }
+            }
+
+            $global:secondRequestInput = @($request.input)
+            $global:secondRequestInstructions = $request.instructions
+            [PSCustomObject]@{
+                output = @(
+                    [PSCustomObject]@{
+                        type    = 'message'
+                        content = @([PSCustomObject]@{ type = 'output_text'; text = 'I loaded the project instructions.' })
+                    }
+                )
+            }
+        }
+
+        Push-Location $TestDrive
+        try {
+            InModuleScope PSAISuite {
+                $global:agentsTestResult = Invoke-OpenAIProvider -ModelName 'gpt-5.6' -Messages @(@{ role = 'user'; content = 'Create and use project instructions' }) -Tools $global:agentsTestTool
+            }
+        }
+        finally {
+            Pop-Location
+            Remove-Item -LiteralPath Function:\New-PSAISuiteTestAgentsFile -ErrorAction SilentlyContinue
+        }
+
+        $global:agentsTestResult.Text | Should -Be 'I loaded the project instructions.'
+        $global:secondRequestInstructions | Should -Match 'Use the project instructions.'
+    }
+
+    It "sends system and developer messages through the Responses instructions field" {
+        $global:capturedInstructions = $null
+        $global:capturedInput = $null
+
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            $request = $Body | ConvertFrom-Json
+            $global:capturedInstructions = $request.instructions
+            $global:capturedInput = @($request.input)
+            [PSCustomObject]@{
+                output = @(
+                    [PSCustomObject]@{
+                        type    = 'message'
+                        content = @([PSCustomObject]@{ type = 'output_text'; text = 'done' })
+                    }
+                )
+            }
+        }
+
+        InModuleScope PSAISuite {
+            $result = Invoke-OpenAIProvider -ModelName 'gpt-5.6' -Messages @(
+                @{ role = 'system'; content = @(@{ type = 'input_text'; text = 'Use standard Markdown links.' }) }
+                @{ role = 'developer'; content = 'Do not include a title.' }
+                @{ role = 'user'; content = 'Write an index.' }
+            )
+        }
+
+        $global:capturedInstructions | Should -BeLike '*Use standard Markdown links.*'
+        $global:capturedInstructions | Should -BeLike '*Do not include a title.*'
+        @($global:capturedInput).Count | Should -Be 1
+        $global:capturedInput[0].role | Should -Be 'user'
+    }
+
+    It "removes instructions from the next request when AGENTS.md is deleted" {
+        $global:openAIRequestCount = 0
+        $global:capturedInstructionsAfterRemoval = 'not-captured'
+        $global:agentsRemovalTestPath = Join-Path $TestDrive 'AGENTS.md'
+        Set-Content -LiteralPath $global:agentsRemovalTestPath -Value 'Remove these instructions after the first round.'
+
+        function global:Remove-PSAISuiteTestAgentsFile {
+            param([string]$Path)
+            Remove-Item -LiteralPath $Path -ErrorAction Stop
+            return 'AGENTS.md removed'
+        }
+
+        $global:agentsRemovalTestTool = @{
+            Name        = 'Remove-PSAISuiteTestAgentsFile'
+            Description = 'Removes the project instruction file.'
+            Parameters  = @{
+                type       = 'object'
+                properties = @{ Path = @{ type = 'string' } }
+                required   = @('Path')
+            }
+        }
+
+        Mock -ModuleName PSAISuite Invoke-RestMethod {
+            $global:openAIRequestCount++
+            $request = $Body | ConvertFrom-Json
+
+            if ($global:openAIRequestCount -eq 1) {
+                return [PSCustomObject]@{
+                    output = @(
+                        [PSCustomObject]@{
+                            type      = 'function_call'
+                            name      = 'Remove-PSAISuiteTestAgentsFile'
+                            arguments = (@{ Path = $global:agentsRemovalTestPath } | ConvertTo-Json -Compress)
+                            call_id   = 'call-agents-removal-1'
+                        }
+                    )
+                }
+            }
+
+            $global:capturedInstructionsAfterRemoval = $request.PSObject.Properties.Name -contains 'instructions'
+            [PSCustomObject]@{
+                output = @(
+                    [PSCustomObject]@{
+                        type    = 'message'
+                        content = @([PSCustomObject]@{ type = 'output_text'; text = 'Instructions were removed.' })
+                    }
+                )
+            }
+        }
+
+        Push-Location $TestDrive
+        try {
+            InModuleScope PSAISuite {
+                $global:agentsRemovalTestResult = Invoke-OpenAIProvider -ModelName 'gpt-5.6' -Messages @(@{ role = 'user'; content = 'Remove the project instructions' }) -Tools $global:agentsRemovalTestTool
+            }
+        }
+        finally {
+            Pop-Location
+            Remove-Item -LiteralPath Function:\Remove-PSAISuiteTestAgentsFile -ErrorAction SilentlyContinue
+        }
+
+        $global:agentsRemovalTestResult.Text | Should -Be 'Instructions were removed.'
+        $global:capturedInstructionsAfterRemoval | Should -BeFalse
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# v0.8.5
+
+- Preserve structured system and developer message content when sending OpenAI Responses API instructions.
+- Remove stale `instructions` data when an `AGENTS.md` file is deleted during a tool workflow.
+- Restore the model-dependent OpenAI `minimal` reasoning effort value.
+- Add OpenAI instruction, tool workflow, and project instruction examples to the README and guide.
+
+# v0.8.4
+
+- OpenAI system and developer messages are sent through the Responses API `instructions` field.
+- OpenAI project instruction refreshes now update the instruction context instead of appending stale developer messages to the input history.
+- Improved the blueprint-driven harness workflow example to support alternate blueprint files and standard Markdown output.
+- Aligned OpenAI effort validation with GPT-5.6 Luna support: `none`, `low`, `medium`, `high`, `xhigh`, and `max`.
+
+# v0.8.3
+
+- Added OpenAI `-MaxIterations` to control the maximum number of tool-calling rounds.
+- OpenAI tool calls now return PowerShell command errors to the model for recovery.
+- Added timestamped OpenAI tool workflow progress and automatic `AGENTS.md` project instruction discovery and refresh.
+
 # v0.8.2
 
 - Added OpenAI `-EffortLevel` and `-SpeedLevel` options to `Invoke-ChatCompletion`.

--- a/guides/openai.md
+++ b/guides/openai.md
@@ -44,6 +44,9 @@ OpenAI requests can optionally use Codex-style effort and speed levels. These
 options are currently supported only by the OpenAI provider and are omitted
 from the request when they are not specified.
 
+Supported effort values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+and `max`; availability depends on the selected OpenAI model.
+
 ```powershell
 $message = New-ChatMessage -Prompt "Solve this carefully."
 
@@ -65,3 +68,51 @@ $result.ServiceTier
 
 The normal output remains response text. Use `-Raw` to inspect the requested
 levels and the effective `ReasoningEffort` and `ServiceTier` returned by OpenAI.
+
+## System instructions
+
+Pass system or developer messages alongside the user message. The OpenAI
+provider moves those messages into the Responses API `instructions` field so
+they remain instruction-level context across tool-calling rounds:
+
+```powershell
+$messages = @(
+    @{ role = 'system'; content = @(@{ type = 'input_text'; text = 'Use standard Markdown links such as [label](path.md).' }) }
+    @{ role = 'developer'; content = 'Keep the response concise.' }
+    @{ role = 'user'; content = 'Create an index of the project.' }
+)
+
+Invoke-ChatCompletion `
+    -Messages $messages `
+    -Model 'openai:gpt-5.6'
+```
+
+For tool-calling workflows, set `-MaxIterations` to allow more successive
+tool calls:
+
+```powershell
+$result = Invoke-ChatCompletion `
+    -Messages "Find the files and summarize their contents." `
+    -Model "openai:gpt-5.6" `
+    -Tools "Get-ChildItem" `
+    -MaxIterations 10 `
+    -Raw
+```
+
+When using tools, `-MaxIterations` controls how many tool-calling rounds are
+allowed before the request stops. It defaults to 5 and can be increased for
+workflows that require several successive tool calls.
+
+## Project instructions
+
+When an `AGENTS.md` file exists in the project root or an applicable
+directory above the current location, the OpenAI provider loads it automatically
+as project guidance.
+The provider checks for new or changed `AGENTS.md` files after each tool round,
+so a file created during the current run is available on the next model turn.
+If an instruction file is removed, it is also removed from the next request.
+
+The provider reports request, tool, and instruction-refresh activity through
+PowerShell progress output. Use `-Verbose` with `Invoke-ChatCompletion` for
+timestamped diagnostic messages. Tool failures are returned to the model as
+function output so it can correct invalid paths or arguments.


### PR DESCRIPTION
## What changed

- Preserve structured system and developer message content when sending OpenAI Responses API instructions.
- Remove stale `instructions` data when `AGENTS.md` is deleted during a tool workflow.
- Restore the model-dependent `minimal` reasoning effort value.
- Update the README, OpenAI guide, changelog, and module version to `0.8.5`.
- Add regression coverage for structured instructions and instruction-file removal.

## Why

The previous implementation stringified structured instruction content and could send `instructions: null` after an instruction file was removed. It also rejected `minimal` before the selected model could determine whether that effort was supported.

## Validation

- 50 Pester tests passed.
- Module manifest validated at version `0.8.5`.
- PSScriptAnalyzer reported no findings.
- PowerShell Gallery publication was intentionally left for the maintainer; the available key returned HTTP 403.